### PR TITLE
Ignore underscored inputs

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d472a26afe4cbe4837137f5c4aa51757783940f7f61f84ea7f2d7579be8e2435"
+content_hash = "sha256:268fbeccd068e3313c30af188270ae60b437ef98b02d16163a941088a2a5ab81"
 
 [[metadata.targets]]
 requires_python = ">=3.13"
@@ -406,7 +406,7 @@ files = [
 
 [[package]]
 name = "koreo-core"
-version = "0.1.8"
+version = "0.1.9"
 requires_python = ">=3.13"
 summary = "Type-safe and testable KRM Templates and Workflows."
 groups = ["default"]
@@ -417,8 +417,8 @@ dependencies = [
     "kr8s==0.20.6",
 ]
 files = [
-    {file = "koreo_core-0.1.8-py3-none-any.whl", hash = "sha256:f786da937ee3626feb75e672f85bb750b4c971fd0743ad122b19da382b0d9a0a"},
-    {file = "koreo_core-0.1.8.tar.gz", hash = "sha256:e83c4d758436e75c573d0493c005de5b2e0d47e2a90535f8197b82937e7fcc66"},
+    {file = "koreo_core-0.1.9-py3-none-any.whl", hash = "sha256:920916af26ef075f301d011020f1ab6866d470e871a7ae21bc6d3a770dad9a40"},
+    {file = "koreo_core-0.1.9.tar.gz", hash = "sha256:fba013aeb624da6e939a4ae949cbf348eadc4facac8bf69a234684478e52375e"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "koreo"
-version = "0.3.0"
+version = "0.3.1"
 description = "Tooling package for Koreo"
 authors = [
     {name = "Robert Kluin", email = "robert.kluin@realkinetic.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "cel-python==0.2.0",
     "pygls==2.0.0a2",
     "pyyaml==6.0.2",
-    "koreo-core==0.1.8",
+    "koreo-core==0.1.9",
     "colorist>=1.8.3",
     "kr8s>=0.20.6",
 ]

--- a/src/koreo_tooling/langserver/workflow.py
+++ b/src/koreo_tooling/langserver/workflow.py
@@ -231,6 +231,9 @@ def _process_workflow_step(
     inputs = call_arg_compare(provided_input_keys, first_tier_inputs)
     for argument, (provided, expected) in inputs.items():
         if not expected and provided:
+            if argument.startswith('_'):
+                continue
+
             has_error = True
 
             # This is not done earlier so that we can still flag issues at the


### PR DESCRIPTION
This allows devs to sequence their workflow steps without warnings by prefixing inputs with an underscore. 