### PR TITLE
Replace PyYAML with ruamel.yaml and use local koreo-core

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:dba794be5857b51d69524f27262bb6a3168abb9fb0da0e444ee8ef5aec92a1ca"
+content_hash = "sha256:0b08a5571f070edd9aa38d1e84e524937dc19fca8e0ec60341ae2d387d334319"
 
 [[metadata.targets]]
 requires_python = ">=3.13"
@@ -53,30 +53,6 @@ files = [
 ]
 
 [[package]]
-name = "black"
-version = "24.10.0"
-requires_python = ">=3.9"
-summary = "The uncompromising code formatter."
-groups = ["dev"]
-dependencies = [
-    "click>=8.0.0",
-    "mypy-extensions>=0.4.3",
-    "packaging>=22.0",
-    "pathspec>=0.9.0",
-    "platformdirs>=2",
-    "tomli>=1.1.0; python_version < \"3.11\"",
-    "typing-extensions>=4.0.1; python_version < \"3.11\"",
-]
-files = [
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
-]
-
-[[package]]
 name = "cachetools"
 version = "5.5.2"
 requires_python = ">=3.7"
@@ -105,21 +81,19 @@ files = [
 
 [[package]]
 name = "cel-python"
-version = "0.2.0"
-requires_python = "<4.0,>=3.8"
+version = "0.3.0"
+requires_python = "<4.0,>=3.9"
 summary = "Pure Python implementation of Google Common Expression Language"
 groups = ["default"]
 dependencies = [
-    "jmespath<2.0.0,>=1.0.1",
-    "lark<0.13.0,>=0.12.0",
-    "python-dateutil<3.0.0,>=2.9.0.post0",
-    "pyyaml<7.0.0,>=6.0.1",
-    "types-python-dateutil<3.0.0.0,>=2.9.0.20240316",
-    "types-pyyaml<7.0.0.0,>=6.0.12.20240311",
+    "lark<0.13,>=0.12",
+    "pendulum<4.0.0,>=3.1.0",
+    "pyyaml<7.0.0,>=6.0.2",
+    "types-pyyaml<7.0.0.0,>=6.0.12.20250516",
 ]
 files = [
-    {file = "cel_python-0.2.0-py3-none-any.whl", hash = "sha256:478ff73def7b39d51e6982f95d937a57c2b088c491c578fe5cecdbd79f476f60"},
-    {file = "cel_python-0.2.0.tar.gz", hash = "sha256:75de72a5cf223ec690b236f0cc24da267219e667bd3e7f8f4f20595fcc1c0c0f"},
+    {file = "cel_python-0.3.0-py3-none-any.whl", hash = "sha256:7db7460f1deed505146f87b94253af80422090ae2a18ea74abca41ff09a9edae"},
+    {file = "cel_python-0.3.0.tar.gz", hash = "sha256:0fb25e0bdf68e738621f1438ecb53f2d2f4e06a48591d6844febe7a1a86e4bfe"},
 ]
 
 [[package]]
@@ -159,26 +133,12 @@ files = [
 ]
 
 [[package]]
-name = "click"
-version = "8.2.1"
-requires_python = ">=3.10"
-summary = "Composable command line interface toolkit"
-groups = ["dev"]
-dependencies = [
-    "colorama; platform_system == \"Windows\"",
-]
-files = [
-    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
-    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["dev"]
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+marker = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -396,36 +356,22 @@ files = [
 ]
 
 [[package]]
-name = "jmespath"
-version = "1.0.1"
-requires_python = ">=3.7"
-summary = "JSON Matching Expressions"
-groups = ["default"]
-files = [
-    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
-    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
-]
-
-[[package]]
 name = "koreo-core"
 version = "0.1.11"
 requires_python = ">=3.13"
+path = "../core"
 summary = "Type-safe and testable KRM Templates and Workflows."
 groups = ["default"]
 dependencies = [
     "PyYAML==6.0.2",
-    "cel-python==0.2.0",
+    "cel-python==0.3.0",
     "fastjsonschema==2.21.1",
-    "kr8s==0.20.6",
-]
-files = [
-    {file = "koreo_core-0.1.11-py3-none-any.whl", hash = "sha256:f866e71ac58dd08d97df4e9c5cda2b23d829478da36619430ad1567ccf9482ff"},
-    {file = "koreo_core-0.1.11.tar.gz", hash = "sha256:a2e37104b51f54fd404a38920d496de91cc8541216f319ee698e8a2558d31666"},
+    "kr8s==0.20.7",
 ]
 
 [[package]]
 name = "kr8s"
-version = "0.20.6"
+version = "0.20.7"
 requires_python = ">=3.9"
 summary = "A Kubernetes API library"
 groups = ["default"]
@@ -442,8 +388,8 @@ dependencies = [
     "typing-extensions>=4.12.2",
 ]
 files = [
-    {file = "kr8s-0.20.6-py3-none-any.whl", hash = "sha256:7051808ea3cfb3d407a9485ac1ef7f228e798ff0ac6fba2399bedcda5a9a67f9"},
-    {file = "kr8s-0.20.6.tar.gz", hash = "sha256:49b017001d7f8d2c2aa5c0b88bd277d97e5ef28f5601c11dee1148d8bf669dbf"},
+    {file = "kr8s-0.20.7-py3-none-any.whl", hash = "sha256:e489b97ff513c167f427f479ad5420c78adffd1a6ce5033b079109374200c0c6"},
+    {file = "kr8s-0.20.7.tar.gz", hash = "sha256:ac45e966beea0f6f92f635b3e61e64b8e27962b4825d77b814a663e819a8ec16"},
 ]
 
 [[package]]
@@ -472,17 +418,6 @@ files = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-requires_python = ">=3.8"
-summary = "Type system extensions for programs checked with the mypy type checker."
-groups = ["dev"]
-files = [
-    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
-    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
@@ -505,25 +440,28 @@ files = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-requires_python = ">=3.8"
-summary = "Utility library for gitignore style pattern matching of file paths."
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.3.8"
+name = "pendulum"
+version = "3.1.0"
 requires_python = ">=3.9"
-summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
-groups = ["dev"]
+summary = "Python datetimes made easy"
+groups = ["default"]
+dependencies = [
+    "python-dateutil>=2.6",
+    "tzdata>=2020.1",
+]
 files = [
-    {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
-    {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
+    {file = "pendulum-3.1.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:28658b0baf4b30eb31d096a375983cfed033e60c0a7bbe94fa23f06cd779b50b"},
+    {file = "pendulum-3.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b114dcb99ce511cb8f5495c7b6f0056b2c3dba444ef1ea6e48030d7371bd531a"},
+    {file = "pendulum-3.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2404a6a54c80252ea393291f0b7f35525a61abae3d795407f34e118a8f133a18"},
+    {file = "pendulum-3.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d06999790d9ee9962a1627e469f98568bf7ad1085553fa3c30ed08b3944a14d7"},
+    {file = "pendulum-3.1.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94751c52f6b7c306734d1044c2c6067a474237e1e5afa2f665d1fbcbbbcf24b3"},
+    {file = "pendulum-3.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5553ac27be05e997ec26d7f004cf72788f4ce11fe60bb80dda604a64055b29d0"},
+    {file = "pendulum-3.1.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f8dee234ca6142bf0514368d01a72945a44685aaa2fc4c14c98d09da9437b620"},
+    {file = "pendulum-3.1.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7378084fe54faab4ee481897a00b710876f2e901ded6221671e827a253e643f2"},
+    {file = "pendulum-3.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8539db7ae2c8da430ac2515079e288948c8ebf7eb1edd3e8281b5cdf433040d6"},
+    {file = "pendulum-3.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:1ce26a608e1f7387cd393fba2a129507c4900958d4f47b90757ec17656856571"},
+    {file = "pendulum-3.1.0-py3-none-any.whl", hash = "sha256:f9178c2a8e291758ade1e8dd6371b1d26d08371b4c7730a6e9a3ef8b16ebae0f"},
+    {file = "pendulum-3.1.0.tar.gz", hash = "sha256:66f96303560f41d097bee7d2dc98ffca716fbb3a832c4b3062034c2d45865015"},
 ]
 
 [[package]]
@@ -672,6 +610,40 @@ files = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.18.14"
+requires_python = ">=3.8"
+summary = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+groups = ["default"]
+dependencies = [
+    "ruamel-yaml-clib>=0.2.7; platform_python_implementation == \"CPython\" and python_version < \"3.14\"",
+]
+files = [
+    {file = "ruamel.yaml-0.18.14-py3-none-any.whl", hash = "sha256:710ff198bb53da66718c7db27eec4fbcc9aa6ca7204e4c1df2f282b6fe5eb6b2"},
+    {file = "ruamel.yaml-0.18.14.tar.gz", hash = "sha256:7227b76aaec364df15936730efbf7d72b30c0b79b1d578bbb8e3dcb2d81f52b7"},
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.12"
+requires_python = ">=3.9"
+summary = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+groups = ["default"]
+marker = "platform_python_implementation == \"CPython\" and python_version < \"3.14\""
+files = [
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e7e3736715fbf53e9be2a79eb4db68e4ed857017344d697e8b9749444ae57475"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b7e75b4965e1d4690e93021adfcecccbca7d61c7bddd8e22406ef2ff20d74ef"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3"},
+    {file = "ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f"},
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.13"
 requires_python = ">=3.7"
@@ -721,17 +693,6 @@ files = [
 ]
 
 [[package]]
-name = "types-python-dateutil"
-version = "2.9.0.20250516"
-requires_python = ">=3.9"
-summary = "Typing stubs for python-dateutil"
-groups = ["default"]
-files = [
-    {file = "types_python_dateutil-2.9.0.20250516-py3-none-any.whl", hash = "sha256:2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93"},
-    {file = "types_python_dateutil-2.9.0.20250516.tar.gz", hash = "sha256:13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5"},
-]
-
-[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250516"
 requires_python = ">=3.9"
@@ -751,6 +712,17 @@ groups = ["default", "dev"]
 files = [
     {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
     {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+requires_python = ">=2"
+summary = "Provider of IANA time zone data"
+groups = ["default"]
+files = [
+    {file = "tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8"},
+    {file = "tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ authors = [
     {name = "Tyler Treat", email = "tyler.treat@realkinetic.com"},
 ]
 dependencies = [
-    "cel-python==0.2.0",
+    "cel-python==0.3.0",
     "pygls==2.0.0a2",
-    "pyyaml==6.0.2",
-    "koreo-core==0.1.11",
+    "ruamel.yaml>=0.18.6",
+    "koreo-core @ file:///${PROJECT_ROOT}/../core",
     "colorist>=1.8.3",
     "kr8s>=0.20.6",
 ]

--- a/src/koreo_tooling/indexing/extractor.py
+++ b/src/koreo_tooling/indexing/extractor.py
@@ -1,9 +1,9 @@
-from typing import Sequence
 import copy
+from collections.abc import Sequence
 
-from yaml.nodes import Node, MappingNode, SequenceNode
+from ruamel.yaml.nodes import MappingNode, Node, SequenceNode
 
-
+from . import cel_semantics
 from .koreo_semantics import ALL
 from .semantics import (
     FieldIndexFn,
@@ -17,8 +17,6 @@ from .semantics import (
     Severity,
     compute_abs_position,
 )
-
-from . import cel_semantics
 
 
 def extract_semantic_structure_info(

--- a/src/koreo_tooling/langserver/codelens.py
+++ b/src/koreo_tooling/langserver/codelens.py
@@ -1,12 +1,12 @@
-from typing import NamedTuple, Sequence
 import copy
-
-import yaml
-
-from lsprotocol import types
+import io
+from collections.abc import Sequence
+from typing import NamedTuple
 
 from koreo import cache
 from koreo.function_test.structure import FunctionTest
+from lsprotocol import types
+from ruamel.yaml import YAML
 
 from koreo_tooling import constants
 from koreo_tooling.function_test import FieldMismatchResult, TestResults
@@ -14,8 +14,8 @@ from koreo_tooling.indexing.semantics import (
     SemanticAnchor,
     SemanticBlock,
     SemanticNode,
-    compute_abs_range,
     compute_abs_position,
+    compute_abs_range,
 )
 from koreo_tooling.langserver.rangers import block_range_extract
 
@@ -397,9 +397,14 @@ def _code_lens_inputs_action(test_name: str, test_result: TestResults):
     )
 
     indent = (offset + 2) * " "
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    stream = io.StringIO()
+    yaml.dump(spec_inputs, stream)
     formated_inputs = f"\n{"\n".join(
         f"{indent}{line}"
-        for line in yaml.dump(spec_inputs).splitlines()
+        for line in stream.getvalue().splitlines()
     )}\n\n"
 
     return EditResult(
@@ -525,9 +530,14 @@ def _code_lens_replace_value_block_action(
     )
 
     indent = (offset + 2) * " "
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 10000
+    stream = io.StringIO()
+    yaml.dump(new_value, stream)
     formated = f"\n{"\n".join(
         f"{indent}{line}"
-        for line in yaml.dump(new_value, width=10000).splitlines()
+        for line in stream.getvalue().splitlines()
     )}\n\n"
 
     return EditResult(

--- a/src/koreo_tooling/langserver/function_test.py
+++ b/src/koreo_tooling/langserver/function_test.py
@@ -1,17 +1,20 @@
-from typing import NamedTuple, Sequence
 import os
+from collections.abc import Sequence
+from typing import NamedTuple
 
 os.environ["KOREO_DEV_TOOLING"] = "true"
 
-from lsprotocol import types
-
 from koreo import cache
 from koreo.function_test.structure import FunctionTest
+from lsprotocol import types
 
 from koreo_tooling import function_test
-from koreo_tooling.indexing import compute_abs_range
-from koreo_tooling.indexing.semantics import SemanticAnchor, SemanticBlock, SemanticNode
-
+from koreo_tooling.indexing.semantics import (
+    SemanticAnchor,
+    SemanticBlock,
+    SemanticNode,
+    compute_abs_range,
+)
 from koreo_tooling.langserver.rangers import block_range_extract
 
 

--- a/src/koreo_tooling/langserver/workflow.py
+++ b/src/koreo_tooling/langserver/workflow.py
@@ -1,20 +1,20 @@
-from typing import NamedTuple, Sequence
 import os
+from collections.abc import Sequence
+from typing import NamedTuple
 
 os.environ["KOREO_DEV_TOOLING"] = "true"
 
 
-from lsprotocol import types
-
 from koreo import cache
-from koreo.workflow.structure import ErrorStep, LogicSwitch, Step, Workflow
 from koreo.resource_function.structure import ResourceFunction
-from koreo.value_function.structure import ValueFunction
 from koreo.result import is_unwrapped_ok
+from koreo.value_function.structure import ValueFunction
+from koreo.workflow.structure import ErrorStep, LogicSwitch, Step, Workflow
+from lsprotocol import types
 
 from koreo_tooling import constants
 from koreo_tooling.analysis import call_arg_compare
-from koreo_tooling.indexing import compute_abs_range
+from koreo_tooling.indexing.semantics import compute_abs_range
 from koreo_tooling.langserver.rangers import block_range_extract
 
 
@@ -138,7 +138,7 @@ def _process_workflow(
     if not step_specs and workflow.steps:
         diagnostics.append(
             types.Diagnostic(
-                message=f"Workflow steps are malformed.",
+                message="Workflow steps are malformed.",
                 severity=types.DiagnosticSeverity.Warning,
                 range=resource_range,
             )
@@ -173,7 +173,7 @@ def _process_workflow(
     if has_step_error:
         diagnostics.append(
             types.Diagnostic(
-                message=f"Workflow steps are not ready.",
+                message="Workflow steps are not ready.",
                 severity=types.DiagnosticSeverity.Error,
                 range=resource_range,
             )

--- a/src/server.py
+++ b/src/server.py
@@ -1,26 +1,26 @@
-from collections import defaultdict
-from pathlib import Path
-import pathlib
-from typing import Callable, NamedTuple, Sequence
 import asyncio
-import time
-
 import logging
+import pathlib
+import time
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import NamedTuple
 
 logger = logging.getLogger("koreo.ls")
 
+from koreo import schema
 from lsprotocol import types
 from pygls.lsp.server import LanguageServer
-from koreo import schema
 
 KOREO_LSP_NAME = "koreo-ls"
 KOREO_LSP_VERSION = "v1beta1"
-CRD_ROOT = pathlib.Path(__file__).parent.joinpath("crd")
+# Use CRD_ROOT from koreo.schema instead of local path
+# CRD_ROOT = pathlib.Path(__file__).parent.joinpath("crd")
 
 server = LanguageServer(KOREO_LSP_NAME, KOREO_LSP_VERSION)
 
-from koreo import cache
-from koreo import registry
+from koreo import cache, registry
 from koreo.function_test.structure import FunctionTest
 from koreo.resource_function.structure import ResourceFunction
 from koreo.resource_template.structure import ResourceTemplate
@@ -30,9 +30,13 @@ from koreo.workflow.structure import Workflow
 
 from koreo_tooling import constants
 from koreo_tooling.function_test import TestResults
-from koreo_tooling.indexing import TokenModifiers, TokenTypes, SemanticAnchor
+from koreo_tooling.indexing import SemanticAnchor, TokenModifiers, TokenTypes
 from koreo_tooling.indexing.semantics import generate_local_range_index
-from koreo_tooling.langserver.codelens import LENS_COMMANDS, EditResult, handle_lens
+from koreo_tooling.langserver.codelens import (
+    LENS_COMMANDS,
+    EditResult,
+    handle_lens,
+)
 from koreo_tooling.langserver.fileprocessor import (
     ProccessResults,
     SemanticRangeIndex,
@@ -413,7 +417,7 @@ async def goto_reference(params: types.ReferenceParams):
 )
 async def semantic_tokens_full(params: types.ReferenceParams):
     doc = server.workspace.get_text_document(params.text_document.uri)
-    if not doc.uri in __SEMANTIC_TOKEN_INDEX:
+    if doc.uri not in __SEMANTIC_TOKEN_INDEX:
         # Once processing has finished, a refresh will be issued.
         await handle_file(
             file_uri=params.text_document.uri,
@@ -466,7 +470,7 @@ async def _parse_file(doc_uri: str):
             for log in processing_result.logs:
                 server.window_log_message(params=log)
 
-    except Exception as err:
+    except Exception:
         return
 
     __PARSING_RESULT[doc_uri] = (doc.version, processing_result)
@@ -861,7 +865,8 @@ def _check_for_duplicate_resources(uri: str):
 
 
 def main():
-    schema.load_validators_from_files(path=CRD_ROOT)
+    # Load validators from koreo-core's CRD directory
+    schema.load_validators_from_files()
     server.start_io()
 
 


### PR DESCRIPTION
- Replace PyYAML with ruamel.yaml for better YAML preservation
- Update IndexingLoader to work with ruamel.yaml architecture
- Switch to local koreo-core package instead of broken 0.1.11-13
- Update cel-python to 0.3.0 to match koreo-core requirements
- Fix imports and exports in indexing module
- Remove local CRD_ROOT to use koreo-core's CRD files