### PR TITLE
Add K8s CRD validation for ResourceFunctions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.ruff_cache

--- a/src/koreo_tooling/__init__.py
+++ b/src/koreo_tooling/__init__.py
@@ -1,0 +1,47 @@
+"""Koreo tooling package initialization"""
+
+import logging
+
+# Module-level logger
+logger = logging.getLogger("koreo.tooling")
+
+# Expose key utilities at package level
+from .cel_utils import CelExpressionDetector, CelPlaceholderGenerator
+from .error_handling import ValidationError
+from .k8s_validation import (
+    get_crd_schema,
+    is_k8s_validation_enabled,
+    set_k8s_validation_enabled,
+    validate_spec,
+    validate_resource_function,
+    validate_resource_function_k8s,
+    is_cel_expression,
+    has_cel_expressions,
+    replace_cel_with_placeholders,
+    clean_schema,
+    make_partial_schema,
+    merge_overlays,
+    is_cel_related_error,
+)
+
+__all__ = [
+    # CEL utilities
+    "CelExpressionDetector",
+    "CelPlaceholderGenerator",
+    # Error handling
+    "ValidationError",
+    # K8s validation
+    "get_crd_schema",
+    "set_k8s_validation_enabled",
+    "is_k8s_validation_enabled",
+    "validate_spec",
+    "validate_resource_function",
+    "validate_resource_function_k8s",
+    "is_cel_expression",
+    "has_cel_expressions",
+    "replace_cel_with_placeholders",
+    "clean_schema",
+    "make_partial_schema",
+    "merge_overlays",
+    "is_cel_related_error",
+]

--- a/src/koreo_tooling/__init__.py
+++ b/src/koreo_tooling/__init__.py
@@ -2,46 +2,42 @@
 
 import logging
 
+from .cel_utils import (
+    has_cel_expressions,
+    is_cel_expression,
+    replace_cel_with_placeholders,
+)
+from .error_handling import ValidationError
+from .k8s_validation import (
+    clean_schema,
+    get_crd_schema,
+    is_k8s_validation_enabled,
+    make_partial_schema,
+    merge_overlays,
+    set_k8s_validation_enabled,
+    validate_resource_function,
+    validate_resource_function_k8s,
+    validate_spec,
+)
+
 # Module-level logger
 logger = logging.getLogger("koreo.tooling")
 
-# Expose key utilities at package level
-from .cel_utils import CelExpressionDetector, CelPlaceholderGenerator
-from .error_handling import ValidationError
-from .k8s_validation import (
-    get_crd_schema,
-    is_k8s_validation_enabled,
-    set_k8s_validation_enabled,
-    validate_spec,
-    validate_resource_function,
-    validate_resource_function_k8s,
-    is_cel_expression,
-    has_cel_expressions,
-    replace_cel_with_placeholders,
-    clean_schema,
-    make_partial_schema,
-    merge_overlays,
-    is_cel_related_error,
-)
-
 __all__ = [
     # CEL utilities
-    "CelExpressionDetector",
-    "CelPlaceholderGenerator",
+    "has_cel_expressions",
+    "is_cel_expression",
+    "replace_cel_with_placeholders",
     # Error handling
     "ValidationError",
     # K8s validation
-    "get_crd_schema",
-    "set_k8s_validation_enabled",
-    "is_k8s_validation_enabled",
-    "validate_spec",
-    "validate_resource_function",
-    "validate_resource_function_k8s",
-    "is_cel_expression",
-    "has_cel_expressions",
-    "replace_cel_with_placeholders",
     "clean_schema",
+    "get_crd_schema",
+    "is_k8s_validation_enabled",
     "make_partial_schema",
     "merge_overlays",
-    "is_cel_related_error",
+    "set_k8s_validation_enabled",
+    "validate_resource_function",
+    "validate_resource_function_k8s",
+    "validate_spec",
 ]

--- a/src/koreo_tooling/cel_utils.py
+++ b/src/koreo_tooling/cel_utils.py
@@ -1,179 +1,65 @@
-"""Utilities for CEL (Common Expression Language) detection and handling"""
+"""Simple utilities for CEL (Common Expression Language) detection and handling"""
 
 from typing import Any
 
 
-class CelExpressionDetector:
-    """Utilities for detecting and working with CEL expressions"""
-    
-    @staticmethod
-    def is_cel_expression(value: Any) -> bool:
-        """Check if a value is a CEL expression (string starting with '=' or containing CEL in multiline)"""
-        if not isinstance(value, str):
-            return False
-        
-        # Direct CEL expression
-        if value.startswith("="):
-            return True
-        
-        # Multi-line string containing CEL expression
-        # Check if it's a multi-line string that contains CEL
-        if "\n" in value and any(line.strip().startswith("=") for line in value.split("\n")):
-            return True
-        
-        # Single line that starts with = after whitespace (YAML folded/literal blocks)
-        stripped = value.strip()
-        if stripped.startswith("="):
-            return True
-        
+def is_cel_expression(value: Any) -> bool:
+    """Check if a value is a CEL expression"""
+    if not isinstance(value, str):
         return False
-    
-    @staticmethod
-    def has_cel_expressions(obj: Any) -> bool:
-        """Recursively check if an object contains any CEL expressions"""
-        if CelExpressionDetector.is_cel_expression(obj):
-            return True
-        if isinstance(obj, dict):
-            return any(CelExpressionDetector.has_cel_expressions(v) for v in obj.values())
-        if isinstance(obj, list):
-            return any(CelExpressionDetector.has_cel_expressions(item) for item in obj)
-        return False
-    
-    @staticmethod
-    def extract_cel_expressions(obj: dict, path_prefix: str = "") -> list[tuple[str, str]]:
-        """Extract all CEL expressions from an object with their paths"""
-        expressions = []
-        
-        def _extract_recursive(current_obj: Any, current_path: str):
-            if CelExpressionDetector.is_cel_expression(current_obj):
-                expressions.append((current_path, current_obj))
-            elif isinstance(current_obj, dict):
-                for key, value in current_obj.items():
-                    new_path = f"{current_path}.{key}" if current_path else key
-                    _extract_recursive(value, new_path)
-            elif isinstance(current_obj, list):
-                for i, item in enumerate(current_obj):
-                    new_path = f"{current_path}[{i}]" if current_path else f"[{i}]"
-                    _extract_recursive(item, new_path)
-        
-        _extract_recursive(obj, path_prefix)
-        return expressions
-    
-    @staticmethod
-    def is_cel_related_error(error_msg: str, original_data: dict) -> bool:
-        """Check if validation error is about a field that contains CEL expressions"""
-        import re
-        
-        # Extract field path from error like "spec.ipCidrRange must contain..."
-        match = re.match(r"spec\.([^\s]+)", error_msg)
-        if not match:
-            return False
-        
-        field_path = match.group(1)
-        current = original_data.get("spec", original_data)
-        
-        # Navigate to the field
-        for part in field_path.split("."):
-            if isinstance(current, dict) and part in current:
-                current = current[part]
-            else:
-                return False
-        
-        return CelExpressionDetector.is_cel_expression(current)
+    return value.strip().startswith("=")
 
 
-class CelPlaceholderGenerator:
-    """Generates appropriate placeholder values for CEL expressions based on expected types"""
+def has_cel_expressions(obj: Any) -> bool:
+    """Recursively check if an object contains any CEL expressions"""
+    if is_cel_expression(obj):
+        return True
+    if isinstance(obj, dict):
+        return any(has_cel_expressions(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(has_cel_expressions(item) for item in obj)
+    return False
+
+
+def replace_cel_with_placeholders(data: dict, schema: dict) -> dict:
+    """Replace CEL expressions with valid placeholder values"""
+    result = {}
+    properties = schema.get("properties", {})
     
-    @staticmethod
-    def get_placeholder_for_type(field_schema: dict, field_name: str = "") -> Any:
-        """Get appropriate placeholder value based on schema type and field name"""
-        field_type = field_schema.get("type")
-        
-        if field_type == "string":
-            return "placeholder-string"
-        elif field_type == "integer":
-            return 1
-        elif field_type == "number":
-            return 1.0
-        elif field_type == "boolean":
-            return True
-        elif field_type == "array":
-            # For arrays, create a placeholder based on items schema
-            items_schema = field_schema.get("items", {})
-            if items_schema:
-                placeholder_item = CelPlaceholderGenerator.get_placeholder_for_type(items_schema)
-                return [placeholder_item] if placeholder_item is not None else []
-            return []
-        elif field_type == "object":
-            return {}
-        else:
-            # Fallback to field name heuristics for common Kubernetes fields
-            return CelPlaceholderGenerator._get_kubernetes_field_placeholder(field_name)
-    
-    @staticmethod
-    def _get_kubernetes_field_placeholder(field_name: str) -> Any:
-        """Get placeholder for common Kubernetes field names when schema type is missing"""
-        if field_name == "env":
-            # Kubernetes env is always an array of objects
-            return [{"name": "PLACEHOLDER", "value": "placeholder"}]
-        elif field_name in ["ports", "containers", "volumes", "volumeMounts"]:
-            # These are typically arrays
-            return []
-        elif field_name in ["labels", "annotations", "selector"]:
-            # These are typically objects
-            return {}
-        else:
-            return "placeholder-string"
-    
-    @staticmethod
-    def replace_cel_with_placeholders(data: dict, schema: dict) -> dict:
-        """Replace CEL expressions with valid placeholder values based on schema types"""
-        result = {}
-        
-        # Get properties from schema
-        properties = schema.get("properties", {})
-        
-        for key, value in data.items():
-            if CelExpressionDetector.is_cel_expression(value):
-                # Replace CEL expression with placeholder based on expected type
-                field_schema = properties.get(key, {})
-                
-                # Special handling for common Kubernetes field names when schema type is missing
-                if not field_schema.get("type"):
-                    result[key] = CelPlaceholderGenerator._get_kubernetes_field_placeholder(key)
-                else:
-                    result[key] = CelPlaceholderGenerator.get_placeholder_for_type(field_schema, key)
-            elif isinstance(value, dict):
-                # Recursively process nested objects
-                field_schema = properties.get(key, {})
-                if "properties" in field_schema:
-                    result[key] = CelPlaceholderGenerator.replace_cel_with_placeholders(value, field_schema)
-                else:
-                    result[key] = CelPlaceholderGenerator.replace_cel_with_placeholders(value, {})
-            elif isinstance(value, list):
-                # Process lists
-                cleaned_list = []
-                list_schema = properties.get(key, {})
-                items_schema = list_schema.get("items", {})
-                
-                for item in value:
-                    if CelExpressionDetector.is_cel_expression(item):
-                        # Use appropriate placeholder for list items
-                        if items_schema:
-                            placeholder = CelPlaceholderGenerator.get_placeholder_for_type(items_schema)
-                            cleaned_list.append(placeholder)
-                        else:
-                            cleaned_list.append("placeholder-string")
-                    elif isinstance(item, dict):
-                        if items_schema and "properties" in items_schema:
-                            cleaned_list.append(CelPlaceholderGenerator.replace_cel_with_placeholders(item, items_schema))
-                        else:
-                            cleaned_list.append(CelPlaceholderGenerator.replace_cel_with_placeholders(item, {}))
-                    else:
-                        cleaned_list.append(item)
-                result[key] = cleaned_list
+    for key, value in data.items():
+        if is_cel_expression(value):
+            # Replace with appropriate placeholder based on schema type
+            field_schema = properties.get(key, {})
+            field_type = field_schema.get("type", "string")
+            
+            if field_type == "integer":
+                result[key] = 1
+            elif field_type == "number":
+                result[key] = 1.0
+            elif field_type == "boolean":
+                result[key] = True
+            elif field_type == "array":
+                result[key] = []
+            elif field_type == "object":
+                result[key] = {}
             else:
-                result[key] = value
-        
-        return result
+                result[key] = "placeholder-string"
+        elif isinstance(value, dict):
+            field_schema = properties.get(key, {})
+            if "properties" in field_schema:
+                result[key] = replace_cel_with_placeholders(value, field_schema)
+            else:
+                result[key] = replace_cel_with_placeholders(value, {})
+        elif isinstance(value, list):
+            result[key] = []
+            for item in value:
+                if is_cel_expression(item):
+                    result[key].append("placeholder-string")
+                elif isinstance(item, dict):
+                    result[key].append(replace_cel_with_placeholders(item, {}))
+                else:
+                    result[key].append(item)
+        else:
+            result[key] = value
+    
+    return result

--- a/src/koreo_tooling/cel_utils.py
+++ b/src/koreo_tooling/cel_utils.py
@@ -1,0 +1,179 @@
+"""Utilities for CEL (Common Expression Language) detection and handling"""
+
+from typing import Any
+
+
+class CelExpressionDetector:
+    """Utilities for detecting and working with CEL expressions"""
+    
+    @staticmethod
+    def is_cel_expression(value: Any) -> bool:
+        """Check if a value is a CEL expression (string starting with '=' or containing CEL in multiline)"""
+        if not isinstance(value, str):
+            return False
+        
+        # Direct CEL expression
+        if value.startswith("="):
+            return True
+        
+        # Multi-line string containing CEL expression
+        # Check if it's a multi-line string that contains CEL
+        if "\n" in value and any(line.strip().startswith("=") for line in value.split("\n")):
+            return True
+        
+        # Single line that starts with = after whitespace (YAML folded/literal blocks)
+        stripped = value.strip()
+        if stripped.startswith("="):
+            return True
+        
+        return False
+    
+    @staticmethod
+    def has_cel_expressions(obj: Any) -> bool:
+        """Recursively check if an object contains any CEL expressions"""
+        if CelExpressionDetector.is_cel_expression(obj):
+            return True
+        if isinstance(obj, dict):
+            return any(CelExpressionDetector.has_cel_expressions(v) for v in obj.values())
+        if isinstance(obj, list):
+            return any(CelExpressionDetector.has_cel_expressions(item) for item in obj)
+        return False
+    
+    @staticmethod
+    def extract_cel_expressions(obj: dict, path_prefix: str = "") -> list[tuple[str, str]]:
+        """Extract all CEL expressions from an object with their paths"""
+        expressions = []
+        
+        def _extract_recursive(current_obj: Any, current_path: str):
+            if CelExpressionDetector.is_cel_expression(current_obj):
+                expressions.append((current_path, current_obj))
+            elif isinstance(current_obj, dict):
+                for key, value in current_obj.items():
+                    new_path = f"{current_path}.{key}" if current_path else key
+                    _extract_recursive(value, new_path)
+            elif isinstance(current_obj, list):
+                for i, item in enumerate(current_obj):
+                    new_path = f"{current_path}[{i}]" if current_path else f"[{i}]"
+                    _extract_recursive(item, new_path)
+        
+        _extract_recursive(obj, path_prefix)
+        return expressions
+    
+    @staticmethod
+    def is_cel_related_error(error_msg: str, original_data: dict) -> bool:
+        """Check if validation error is about a field that contains CEL expressions"""
+        import re
+        
+        # Extract field path from error like "spec.ipCidrRange must contain..."
+        match = re.match(r"spec\.([^\s]+)", error_msg)
+        if not match:
+            return False
+        
+        field_path = match.group(1)
+        current = original_data.get("spec", original_data)
+        
+        # Navigate to the field
+        for part in field_path.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                return False
+        
+        return CelExpressionDetector.is_cel_expression(current)
+
+
+class CelPlaceholderGenerator:
+    """Generates appropriate placeholder values for CEL expressions based on expected types"""
+    
+    @staticmethod
+    def get_placeholder_for_type(field_schema: dict, field_name: str = "") -> Any:
+        """Get appropriate placeholder value based on schema type and field name"""
+        field_type = field_schema.get("type")
+        
+        if field_type == "string":
+            return "placeholder-string"
+        elif field_type == "integer":
+            return 1
+        elif field_type == "number":
+            return 1.0
+        elif field_type == "boolean":
+            return True
+        elif field_type == "array":
+            # For arrays, create a placeholder based on items schema
+            items_schema = field_schema.get("items", {})
+            if items_schema:
+                placeholder_item = CelPlaceholderGenerator.get_placeholder_for_type(items_schema)
+                return [placeholder_item] if placeholder_item is not None else []
+            return []
+        elif field_type == "object":
+            return {}
+        else:
+            # Fallback to field name heuristics for common Kubernetes fields
+            return CelPlaceholderGenerator._get_kubernetes_field_placeholder(field_name)
+    
+    @staticmethod
+    def _get_kubernetes_field_placeholder(field_name: str) -> Any:
+        """Get placeholder for common Kubernetes field names when schema type is missing"""
+        if field_name == "env":
+            # Kubernetes env is always an array of objects
+            return [{"name": "PLACEHOLDER", "value": "placeholder"}]
+        elif field_name in ["ports", "containers", "volumes", "volumeMounts"]:
+            # These are typically arrays
+            return []
+        elif field_name in ["labels", "annotations", "selector"]:
+            # These are typically objects
+            return {}
+        else:
+            return "placeholder-string"
+    
+    @staticmethod
+    def replace_cel_with_placeholders(data: dict, schema: dict) -> dict:
+        """Replace CEL expressions with valid placeholder values based on schema types"""
+        result = {}
+        
+        # Get properties from schema
+        properties = schema.get("properties", {})
+        
+        for key, value in data.items():
+            if CelExpressionDetector.is_cel_expression(value):
+                # Replace CEL expression with placeholder based on expected type
+                field_schema = properties.get(key, {})
+                
+                # Special handling for common Kubernetes field names when schema type is missing
+                if not field_schema.get("type"):
+                    result[key] = CelPlaceholderGenerator._get_kubernetes_field_placeholder(key)
+                else:
+                    result[key] = CelPlaceholderGenerator.get_placeholder_for_type(field_schema, key)
+            elif isinstance(value, dict):
+                # Recursively process nested objects
+                field_schema = properties.get(key, {})
+                if "properties" in field_schema:
+                    result[key] = CelPlaceholderGenerator.replace_cel_with_placeholders(value, field_schema)
+                else:
+                    result[key] = CelPlaceholderGenerator.replace_cel_with_placeholders(value, {})
+            elif isinstance(value, list):
+                # Process lists
+                cleaned_list = []
+                list_schema = properties.get(key, {})
+                items_schema = list_schema.get("items", {})
+                
+                for item in value:
+                    if CelExpressionDetector.is_cel_expression(item):
+                        # Use appropriate placeholder for list items
+                        if items_schema:
+                            placeholder = CelPlaceholderGenerator.get_placeholder_for_type(items_schema)
+                            cleaned_list.append(placeholder)
+                        else:
+                            cleaned_list.append("placeholder-string")
+                    elif isinstance(item, dict):
+                        if items_schema and "properties" in items_schema:
+                            cleaned_list.append(CelPlaceholderGenerator.replace_cel_with_placeholders(item, items_schema))
+                        else:
+                            cleaned_list.append(CelPlaceholderGenerator.replace_cel_with_placeholders(item, {}))
+                    else:
+                        cleaned_list.append(item)
+                result[key] = cleaned_list
+            else:
+                result[key] = value
+        
+        return result

--- a/src/koreo_tooling/cel_utils.py
+++ b/src/koreo_tooling/cel_utils.py
@@ -1,5 +1,3 @@
-"""Simple utilities for CEL (Common Expression Language) detection and handling"""
-
 from typing import Any
 
 
@@ -25,13 +23,13 @@ def replace_cel_with_placeholders(data: dict, schema: dict) -> dict:
     """Replace CEL expressions with valid placeholder values"""
     result = {}
     properties = schema.get("properties", {})
-    
+
     for key, value in data.items():
         if is_cel_expression(value):
             # Replace with appropriate placeholder based on schema type
             field_schema = properties.get(key, {})
             field_type = field_schema.get("type", "string")
-            
+
             if field_type == "integer":
                 result[key] = 1
             elif field_type == "number":
@@ -61,5 +59,5 @@ def replace_cel_with_placeholders(data: dict, schema: dict) -> dict:
                     result[key].append(item)
         else:
             result[key] = value
-    
+
     return result

--- a/src/koreo_tooling/error_handling.py
+++ b/src/koreo_tooling/error_handling.py
@@ -1,0 +1,208 @@
+"""Unified error handling and diagnostic conversion for Koreo tooling"""
+
+import re
+from dataclasses import dataclass
+
+from lsprotocol import types
+
+
+@dataclass
+class ValidationError:
+    """Unified validation error with position information"""
+    message: str
+    path: str = ""
+    line: int = 0
+    character: int = 0
+    end_line: int | None = None
+    end_character: int | None = None
+    severity: types.DiagnosticSeverity = types.DiagnosticSeverity.Error
+    source: str = "koreo"
+    
+    def to_diagnostic(self) -> types.Diagnostic:
+        """Convert to LSP Diagnostic with smart range calculation"""
+        # Calculate end position based on error type
+        if self.end_character is not None:
+            # Use end_line if specified, otherwise same line
+            end_line = self.end_line if self.end_line is not None else self.line
+            end_pos = types.Position(line=end_line, character=self.end_character)
+        else:
+            # Smart end position calculation
+            if 'must contain' in self.message or 'is required' in self.message:
+                # For missing fields, highlight more of the line
+                end_char = self.character + 40
+            elif 'Unknown field' in self.message or 'additional property' in self.message:
+                # For extra fields, try to highlight just the field name
+                match = re.search(r"'([^']+)'", self.message)
+                if match:
+                    field_name = match.group(1)
+                    end_char = self.character + len(field_name) + 2  # +2 for quotes
+                else:
+                    end_char = self.character + 20
+            else:
+                # Default highlighting
+                field_length = len(self.path.split(".")[-1]) if self.path else 10
+                end_char = self.character + field_length
+            
+            end_pos = types.Position(line=self.line, character=end_char)
+        
+        return types.Diagnostic(
+            range=types.Range(
+                start=types.Position(line=self.line, character=self.character),
+                end=end_pos
+            ),
+            message=self.message,
+            severity=self.severity,
+            source=self.source
+        )
+
+
+class ErrorFormatter:
+    """Utilities for formatting errors for different outputs"""
+    
+    @staticmethod
+    def format_for_cli(errors: list[ValidationError]) -> str:
+        """Format validation errors for CLI output"""
+        if not errors:
+            return "No validation errors found."
+        
+        formatted_lines = []
+        for error in errors:
+            location = f"line {error.line + 1}" if error.line > 0 else "unknown location"
+            if error.path:
+                location += f" ({error.path})"
+            
+            severity_symbol = "❌" if error.severity == types.DiagnosticSeverity.Error else "⚠️"
+            formatted_lines.append(f"{severity_symbol} {location}: {error.message}")
+        
+        return "\n".join(formatted_lines)
+    
+    @staticmethod
+    def format_for_lsp(errors: list[ValidationError]) -> list[types.Diagnostic]:
+        """Convert validation errors to LSP diagnostics"""
+        return [error.to_diagnostic() for error in errors]
+    
+    @staticmethod
+    def format_cli_errors(errors: list[ValidationError], file_path) -> str:
+        """Format validation errors for CLI output with file path"""
+        if not errors:
+            return f"\n{file_path}: No validation errors found."
+        
+        output = [f"\n{file_path}"]
+        
+        for error in errors:
+            severity_label = {
+                1: "ERROR",   # Error
+                2: "WARNING", # Warning  
+                3: "INFO",    # Information
+                4: "HINT",    # Hint
+            }.get(error.severity.value, "UNKNOWN")
+            
+            location = f"line {error.line + 1}" if error.line > 0 else "document"
+            if error.path:
+                location += f", {error.path}"
+            
+            output.append(f"  [{severity_label}] {error.message} ({location})")
+        
+        return "\n".join(output)
+    
+    @staticmethod
+    def extract_path_from_error_message(error_message: str) -> str:
+        """Extract field path from schema validation error message"""
+        # Example: "spec.steps[0].label is required" -> "spec.steps[0].label"
+        
+        # Look for "spec.something" patterns
+        match = re.search(r'spec\.[\w\[\]\.]+', error_message)
+        if match:
+            return match.group()
+        
+        # Look for field names in quotes
+        match = re.search(r"'([^']+)'", error_message)
+        if match:
+            return f"spec.{match.group(1)}"
+        
+        return "spec"
+    
+    @staticmethod
+    def extract_field_from_message(message: str) -> str | None:
+        """Extract field name from error message"""
+        
+        # Pattern for "Unknown field 'fieldname'"
+        match = re.search(r"Unknown field '([^']+)'", message)
+        if match:
+            return match.group(1)
+        
+        # Pattern for "additional property 'fieldname'"
+        match = re.search(r"additional property '([^']+)'", message)
+        if match:
+            return match.group(1)
+        
+        # Pattern for field names in square brackets
+        match = re.search(r"\['([^']+)'\]", message)
+        if match:
+            return match.group(1)
+        
+        return None
+
+
+class ErrorCollector:
+    """Utility for collecting and managing validation errors"""
+    
+    def __init__(self, source: str = "koreo"):
+        self.errors: list[ValidationError] = []
+        self.source = source
+    
+    def add_error(self, message: str, path: str = "", line: int = 0, 
+                  character: int = 0, severity: types.DiagnosticSeverity = types.DiagnosticSeverity.Error):
+        """Add a validation error"""
+        self.errors.append(ValidationError(
+            message=message,
+            path=path,
+            line=line,
+            character=character,
+            severity=severity,
+            source=self.source
+        ))
+    
+    def add_warning(self, message: str, path: str = "", line: int = 0, character: int = 0):
+        """Add a validation warning"""
+        self.add_error(message, path, line, character, types.DiagnosticSeverity.Warning)
+    
+    def extend(self, other_errors: list[ValidationError]):
+        """Add multiple errors from another source"""
+        self.errors.extend(other_errors)
+    
+    def has_errors(self) -> bool:
+        """Check if any errors were collected"""
+        return len(self.errors) > 0
+    
+    def has_error_level(self) -> bool:
+        """Check if any error-level (not warning) issues were found"""
+        return any(error.severity == types.DiagnosticSeverity.Error for error in self.errors)
+    
+    def get_errors(self) -> list[ValidationError]:
+        """Get all collected errors"""
+        return self.errors.copy()
+    
+    def clear(self):
+        """Clear all collected errors"""
+        self.errors.clear()
+
+
+def create_yaml_parse_error(yaml_error: Exception, yaml_content: str = "") -> ValidationError:
+    """Create a ValidationError from a YAML parsing exception"""
+    if hasattr(yaml_error, 'problem_mark') and yaml_error.problem_mark:
+        return ValidationError(
+            message=f"YAML parsing error: {yaml_error}",
+            line=yaml_error.problem_mark.line,
+            character=yaml_error.problem_mark.column,
+            severity=types.DiagnosticSeverity.Error,
+            source="yaml-parser"
+        )
+    else:
+        return ValidationError(
+            message=f"YAML parsing error: {yaml_error}",
+            line=0,
+            character=0,
+            severity=types.DiagnosticSeverity.Error,
+            source="yaml-parser"
+        )

--- a/src/koreo_tooling/error_handling.py
+++ b/src/koreo_tooling/error_handling.py
@@ -8,14 +8,17 @@ from lsprotocol import types
 @dataclass
 class ValidationError:
     """Simple validation error with position information"""
+
     message: str
     path: str = ""
     line: int = 0
     character: int = 0
     severity: types.DiagnosticSeverity = types.DiagnosticSeverity.Error
     source: str = "koreo"
-    
-    def to_diagnostic(self, range_override: types.Range = None) -> types.Diagnostic:
+
+    def to_diagnostic(
+        self, range_override: types.Range = None
+    ) -> types.Diagnostic:
         """Convert to LSP Diagnostic"""
         if range_override:
             diagnostic_range = range_override
@@ -24,12 +27,12 @@ class ValidationError:
             end_char = self.character + 20
             diagnostic_range = types.Range(
                 start=types.Position(line=self.line, character=self.character),
-                end=types.Position(line=self.line, character=end_char)
+                end=types.Position(line=self.line, character=end_char),
             )
-        
+
         return types.Diagnostic(
             range=diagnostic_range,
             message=self.message,
             severity=self.severity,
-            source=self.source
+            source=self.source,
         )

--- a/src/koreo_tooling/error_handling.py
+++ b/src/koreo_tooling/error_handling.py
@@ -1,6 +1,5 @@
-"""Unified error handling and diagnostic conversion for Koreo tooling"""
+"""Simple error handling for validation diagnostics"""
 
-import re
 from dataclasses import dataclass
 
 from lsprotocol import types
@@ -8,201 +7,29 @@ from lsprotocol import types
 
 @dataclass
 class ValidationError:
-    """Unified validation error with position information"""
+    """Simple validation error with position information"""
     message: str
     path: str = ""
     line: int = 0
     character: int = 0
-    end_line: int | None = None
-    end_character: int | None = None
     severity: types.DiagnosticSeverity = types.DiagnosticSeverity.Error
     source: str = "koreo"
     
-    def to_diagnostic(self) -> types.Diagnostic:
-        """Convert to LSP Diagnostic with smart range calculation"""
-        # Calculate end position based on error type
-        if self.end_character is not None:
-            # Use end_line if specified, otherwise same line
-            end_line = self.end_line if self.end_line is not None else self.line
-            end_pos = types.Position(line=end_line, character=self.end_character)
+    def to_diagnostic(self, range_override: types.Range = None) -> types.Diagnostic:
+        """Convert to LSP Diagnostic"""
+        if range_override:
+            diagnostic_range = range_override
         else:
-            # Smart end position calculation
-            if 'must contain' in self.message or 'is required' in self.message:
-                # For missing fields, highlight more of the line
-                end_char = self.character + 40
-            elif 'Unknown field' in self.message or 'additional property' in self.message:
-                # For extra fields, try to highlight just the field name
-                match = re.search(r"'([^']+)'", self.message)
-                if match:
-                    field_name = match.group(1)
-                    end_char = self.character + len(field_name) + 2  # +2 for quotes
-                else:
-                    end_char = self.character + 20
-            else:
-                # Default highlighting
-                field_length = len(self.path.split(".")[-1]) if self.path else 10
-                end_char = self.character + field_length
-            
-            end_pos = types.Position(line=self.line, character=end_char)
+            # Simple range - highlight a reasonable portion
+            end_char = self.character + 20
+            diagnostic_range = types.Range(
+                start=types.Position(line=self.line, character=self.character),
+                end=types.Position(line=self.line, character=end_char)
+            )
         
         return types.Diagnostic(
-            range=types.Range(
-                start=types.Position(line=self.line, character=self.character),
-                end=end_pos
-            ),
+            range=diagnostic_range,
             message=self.message,
             severity=self.severity,
             source=self.source
-        )
-
-
-class ErrorFormatter:
-    """Utilities for formatting errors for different outputs"""
-    
-    @staticmethod
-    def format_for_cli(errors: list[ValidationError]) -> str:
-        """Format validation errors for CLI output"""
-        if not errors:
-            return "No validation errors found."
-        
-        formatted_lines = []
-        for error in errors:
-            location = f"line {error.line + 1}" if error.line > 0 else "unknown location"
-            if error.path:
-                location += f" ({error.path})"
-            
-            severity_symbol = "❌" if error.severity == types.DiagnosticSeverity.Error else "⚠️"
-            formatted_lines.append(f"{severity_symbol} {location}: {error.message}")
-        
-        return "\n".join(formatted_lines)
-    
-    @staticmethod
-    def format_for_lsp(errors: list[ValidationError]) -> list[types.Diagnostic]:
-        """Convert validation errors to LSP diagnostics"""
-        return [error.to_diagnostic() for error in errors]
-    
-    @staticmethod
-    def format_cli_errors(errors: list[ValidationError], file_path) -> str:
-        """Format validation errors for CLI output with file path"""
-        if not errors:
-            return f"\n{file_path}: No validation errors found."
-        
-        output = [f"\n{file_path}"]
-        
-        for error in errors:
-            severity_label = {
-                1: "ERROR",   # Error
-                2: "WARNING", # Warning  
-                3: "INFO",    # Information
-                4: "HINT",    # Hint
-            }.get(error.severity.value, "UNKNOWN")
-            
-            location = f"line {error.line + 1}" if error.line > 0 else "document"
-            if error.path:
-                location += f", {error.path}"
-            
-            output.append(f"  [{severity_label}] {error.message} ({location})")
-        
-        return "\n".join(output)
-    
-    @staticmethod
-    def extract_path_from_error_message(error_message: str) -> str:
-        """Extract field path from schema validation error message"""
-        # Example: "spec.steps[0].label is required" -> "spec.steps[0].label"
-        
-        # Look for "spec.something" patterns
-        match = re.search(r'spec\.[\w\[\]\.]+', error_message)
-        if match:
-            return match.group()
-        
-        # Look for field names in quotes
-        match = re.search(r"'([^']+)'", error_message)
-        if match:
-            return f"spec.{match.group(1)}"
-        
-        return "spec"
-    
-    @staticmethod
-    def extract_field_from_message(message: str) -> str | None:
-        """Extract field name from error message"""
-        
-        # Pattern for "Unknown field 'fieldname'"
-        match = re.search(r"Unknown field '([^']+)'", message)
-        if match:
-            return match.group(1)
-        
-        # Pattern for "additional property 'fieldname'"
-        match = re.search(r"additional property '([^']+)'", message)
-        if match:
-            return match.group(1)
-        
-        # Pattern for field names in square brackets
-        match = re.search(r"\['([^']+)'\]", message)
-        if match:
-            return match.group(1)
-        
-        return None
-
-
-class ErrorCollector:
-    """Utility for collecting and managing validation errors"""
-    
-    def __init__(self, source: str = "koreo"):
-        self.errors: list[ValidationError] = []
-        self.source = source
-    
-    def add_error(self, message: str, path: str = "", line: int = 0, 
-                  character: int = 0, severity: types.DiagnosticSeverity = types.DiagnosticSeverity.Error):
-        """Add a validation error"""
-        self.errors.append(ValidationError(
-            message=message,
-            path=path,
-            line=line,
-            character=character,
-            severity=severity,
-            source=self.source
-        ))
-    
-    def add_warning(self, message: str, path: str = "", line: int = 0, character: int = 0):
-        """Add a validation warning"""
-        self.add_error(message, path, line, character, types.DiagnosticSeverity.Warning)
-    
-    def extend(self, other_errors: list[ValidationError]):
-        """Add multiple errors from another source"""
-        self.errors.extend(other_errors)
-    
-    def has_errors(self) -> bool:
-        """Check if any errors were collected"""
-        return len(self.errors) > 0
-    
-    def has_error_level(self) -> bool:
-        """Check if any error-level (not warning) issues were found"""
-        return any(error.severity == types.DiagnosticSeverity.Error for error in self.errors)
-    
-    def get_errors(self) -> list[ValidationError]:
-        """Get all collected errors"""
-        return self.errors.copy()
-    
-    def clear(self):
-        """Clear all collected errors"""
-        self.errors.clear()
-
-
-def create_yaml_parse_error(yaml_error: Exception, yaml_content: str = "") -> ValidationError:
-    """Create a ValidationError from a YAML parsing exception"""
-    if hasattr(yaml_error, 'problem_mark') and yaml_error.problem_mark:
-        return ValidationError(
-            message=f"YAML parsing error: {yaml_error}",
-            line=yaml_error.problem_mark.line,
-            character=yaml_error.problem_mark.column,
-            severity=types.DiagnosticSeverity.Error,
-            source="yaml-parser"
-        )
-    else:
-        return ValidationError(
-            message=f"YAML parsing error: {yaml_error}",
-            line=0,
-            character=0,
-            severity=types.DiagnosticSeverity.Error,
-            source="yaml-parser"
         )

--- a/src/koreo_tooling/function_test.py
+++ b/src/koreo_tooling/function_test.py
@@ -3,10 +3,15 @@ from collections.abc import Sequence
 from typing import Any, Literal, NamedTuple
 
 from celpy import celtypes
-from koreo import DepSkip, Ok, PermFail, Retry, Skip, cache, registry
+from koreo import cache, registry
 from koreo.function_test.run import run_function_test
 from koreo.function_test.structure import FunctionTest
 from koreo.result import (
+    DepSkip,
+    Ok,
+    PermFail,
+    Retry,
+    Skip,
     UnwrappedOutcome,
     is_unwrapped_ok,
 )

--- a/src/koreo_tooling/indexing/extractor.py
+++ b/src/koreo_tooling/indexing/extractor.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 from yaml.nodes import MappingNode, Node, SequenceNode
 
+from koreo_tooling.cel_utils import is_cel_expression
 from . import cel_semantics
 from .koreo_semantics import ALL
 from .semantics import (
@@ -484,7 +485,7 @@ def _extract_value_semantic_info(
         else:
             node_type = "string"
 
-    if node_type == "string" and yaml_node.value.strip().startswith("="):
+    if node_type == "string" and is_cel_expression(yaml_node.value):
         return _extract_cel_semantic_info(
             anchor_abs_start=anchor_abs_start,
             last_token_abs_start=last_token_abs_start,

--- a/src/koreo_tooling/indexing/extractor.py
+++ b/src/koreo_tooling/indexing/extractor.py
@@ -484,7 +484,7 @@ def _extract_value_semantic_info(
         else:
             node_type = "string"
 
-    if node_type == "string" and yaml_node.value.startswith("="):
+    if node_type == "string" and yaml_node.value.strip().startswith("="):
         return _extract_cel_semantic_info(
             anchor_abs_start=anchor_abs_start,
             last_token_abs_start=last_token_abs_start,

--- a/src/koreo_tooling/indexing/extractor.py
+++ b/src/koreo_tooling/indexing/extractor.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from yaml.nodes import MappingNode, Node, SequenceNode
 
 from koreo_tooling.cel_utils import is_cel_expression
+
 from . import cel_semantics
 from .koreo_semantics import ALL
 from .semantics import (

--- a/src/koreo_tooling/indexing/koreo_semantics.py
+++ b/src/koreo_tooling/indexing/koreo_semantics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from koreo_tooling.cel_utils import is_cel_expression
+
 from .semantics import Modifier, SemanticStructure
 
 ALL = "*"
@@ -246,7 +248,7 @@ SEMANTIC_TYPE_STRUCTURE: dict[str, SemanticStructure] = {
                                     type="string",
                                     index_key_fn=lambda value: (
                                         None
-                                        if value.strip().startswith("=")
+                                        if is_cel_expression(value)
                                         else f"ResourceTemplate:{value}:ref"
                                     ),
                                 ),

--- a/src/koreo_tooling/indexing/koreo_semantics.py
+++ b/src/koreo_tooling/indexing/koreo_semantics.py
@@ -246,7 +246,7 @@ SEMANTIC_TYPE_STRUCTURE: dict[str, SemanticStructure] = {
                                     type="string",
                                     index_key_fn=lambda value: (
                                         None
-                                        if value.startswith("=")
+                                        if value.strip().startswith("=")
                                         else f"ResourceTemplate:{value}:ref"
                                     ),
                                 ),

--- a/src/koreo_tooling/k8s_validation.py
+++ b/src/koreo_tooling/k8s_validation.py
@@ -2,9 +2,8 @@
 
 NOTE: This module requires access to a Kubernetes cluster with installed CRDs.
 If you don't have cluster access or kubectl is not available, you can:
-1. Use the --skip-k8s flag in the CLI to disable CRD validation
-2. Set KOREO_SKIP_K8S_VALIDATION=1 environment variable
-3. Check debug logs for cluster connection issues
+1. Set KOREO_SKIP_K8S_VALIDATION=1 environment variable
+2. Check debug logs for cluster connection issues
 """
 
 import json
@@ -164,9 +163,7 @@ def get_crd_schema(
         _CRD_SCHEMA_CACHE[cache_key] = None
         return None
     except FileNotFoundError:
-        logger.debug(
-            "kubectl command not found - please install kubectl or disable K8s validation"  # noqa: E501
-        )
+        logger.debug("kubectl command not found - please install kubectl")
         _CRD_SCHEMA_CACHE[cache_key] = None
         return None
     except json.JSONDecodeError as e:

--- a/src/koreo_tooling/k8s_validation.py
+++ b/src/koreo_tooling/k8s_validation.py
@@ -246,15 +246,15 @@ def validate_spec(
     allow_partial: bool = False,
 ) -> list[str]:
     """Validate resource spec against CRD schema (type checking only).
-    
+
     This function performs type validation to ensure fields have the correct
     data types (string, integer, boolean, etc.) according to the CRD schema.
-    
+
     NOTE: This does NOT validate required fields. This is intentional because:
     - ResourceFunctions often use overlays that provide missing fields
     - CEL expressions may compute values dynamically
     - Partial specs are common in Koreo workflows
-    
+
     For full validation including required fields, use kubectl dry-run.
     """
     schema = get_crd_schema(api_version, kind, plural)
@@ -356,11 +356,11 @@ def merge_overlays(base: dict, *overlays: dict) -> dict:
 
 
 def validate_resource_function(spec: dict) -> list[ValidationError]:
-    """Validate ResourceFunction spec with K8s CRD validation (type checking only).
+    """Validate ResourceFunction spec with K8s CRD validation.
 
-    Performs type validation on ResourceFunction specs against their CRD schemas.
+    Performs type validation on ResourceFunction specs against the CRD schemas.
     This validates that fields have correct data types but does NOT check for
-    required fields, as ResourceFunctions commonly use overlays and CEL 
+    required fields, as ResourceFunctions commonly use overlays and CEL
     expressions.
 
     If K8s validation is disabled, returns empty list.

--- a/src/koreo_tooling/k8s_validation.py
+++ b/src/koreo_tooling/k8s_validation.py
@@ -1,0 +1,490 @@
+"""Kubernetes CRD validation for ResourceFunction specifications
+
+NOTE: This module requires access to a Kubernetes cluster with installed CRDs.
+If you don't have cluster access or kubectl is not available, you can:
+1. Use the --skip-k8s flag in the CLI to disable CRD validation
+2. Set KOREO_SKIP_K8S_VALIDATION=1 environment variable
+3. Check debug logs for cluster connection issues
+"""
+
+import json
+import logging
+import os
+import subprocess
+from copy import deepcopy
+
+
+from .cel_utils import CelExpressionDetector, CelPlaceholderGenerator
+from .error_handling import ValidationError as BaseValidationError
+
+logger = logging.getLogger("koreo.tooling.k8s_validation")
+
+# Global flag to disable K8s validation
+_K8S_VALIDATION_DISABLED = False
+
+
+# Cache for CRD schemas to avoid repeated kubectl calls
+_CRD_SCHEMA_CACHE = {}
+
+# Cache for compiled schema validators
+_SCHEMA_VALIDATOR_CACHE = {}
+
+
+def set_k8s_validation_enabled(enabled: bool) -> None:
+    """Enable or disable K8s CRD validation globally"""
+    global _K8S_VALIDATION_DISABLED
+    _K8S_VALIDATION_DISABLED = not enabled
+    if not enabled:
+        logger.info("K8s CRD validation disabled")
+
+
+def is_k8s_validation_enabled() -> bool:
+    """Check if K8s CRD validation is enabled"""
+    if _K8S_VALIDATION_DISABLED:
+        return False
+
+    # Check environment variable
+    if os.getenv("KOREO_SKIP_K8S_VALIDATION", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    ):
+        logger.debug(
+            "K8s validation disabled via KOREO_SKIP_K8S_VALIDATION environment variable"
+        )
+        return False
+
+    return True
+
+
+def clear_crd_cache() -> None:
+    """Clear the CRD schema cache (useful for development/testing)"""
+    global _CRD_SCHEMA_CACHE, _SCHEMA_VALIDATOR_CACHE
+    _CRD_SCHEMA_CACHE.clear()
+    _SCHEMA_VALIDATOR_CACHE.clear()
+    logger.debug("CRD schema and validator caches cleared")
+
+
+class ValidationError(BaseValidationError):
+    """K8s validation error - extends base ValidationError"""
+
+    def __init__(
+        self,
+        path: str,
+        message: str,
+        severity: str = "error",
+        line: int = 0,
+        character: int = 0,
+        end_character: int = 0,
+    ):
+        # Convert string severity to DiagnosticSeverity
+        from lsprotocol import types
+
+        diagnostic_severity = (
+            types.DiagnosticSeverity.Error
+            if severity == "error"
+            else types.DiagnosticSeverity.Warning
+        )
+
+        super().__init__(
+            message=message,
+            path=path,
+            line=line,
+            character=character,
+            end_character=end_character,
+            severity=diagnostic_severity,
+            source="koreo-k8s",
+        )
+
+
+# Re-export CEL utilities for backward compatibility
+is_cel_expression = CelExpressionDetector.is_cel_expression
+has_cel_expressions = CelExpressionDetector.has_cel_expressions
+
+
+# Re-export CEL placeholder utilities for backward compatibility
+replace_cel_with_placeholders = (
+    CelPlaceholderGenerator.replace_cel_with_placeholders
+)
+
+
+# Re-export CEL detection utility for backward compatibility
+is_cel_related_error = CelExpressionDetector.is_cel_related_error
+
+
+def get_crd_schema(
+    api_version: str, kind: str, plural: str | None = None
+) -> dict | None:
+    """Fetch CRD schema from local Kubernetes cluster with caching
+
+    Returns None if:
+    - Resource is a built-in Kubernetes resource
+    - K8s validation is disabled
+    - Cluster is not accessible
+    - CRD doesn't exist
+    """
+    if not is_k8s_validation_enabled():
+        return None
+
+    # Create cache key
+    cache_key = f"{api_version}/{kind}/{plural or 'default'}"
+    if cache_key in _CRD_SCHEMA_CACHE:
+        return _CRD_SCHEMA_CACHE[cache_key]
+    # Skip built-in resources
+    builtin_resources = {
+        "v1": [
+            "Pod",
+            "Service",
+            "PersistentVolume",
+            "PersistentVolumeClaim",
+            "ConfigMap",
+            "Secret",
+            "Namespace",
+        ],
+        "apps/v1": ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"],
+        "batch/v1": ["Job"],
+        "batch/v1beta1": ["CronJob"],
+        "networking.k8s.io/v1": ["Ingress", "NetworkPolicy"],
+        "rbac.authorization.k8s.io/v1": [
+            "Role",
+            "RoleBinding",
+            "ClusterRole",
+            "ClusterRoleBinding",
+        ],
+    }
+
+    if (
+        api_version in builtin_resources
+        and kind in builtin_resources[api_version]
+    ):
+        return None
+
+    # Build CRD name
+    if "/" in api_version:
+        group, version = api_version.split("/", 1)
+    else:
+        group, version = "", api_version
+
+    crd_name = (
+        f"{plural or kind.lower() + 's'}.{group}"
+        if group
+        else (plural or kind.lower() + "s")
+    )
+
+    try:
+        result = subprocess.run(
+            ["kubectl", "get", "crd", crd_name, "-o", "json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode != 0:
+            logger.debug(
+                f"CRD '{crd_name}' not found in cluster: {result.stderr.strip()}"
+            )
+            return None
+
+        crd = json.loads(result.stdout)
+
+        # Extract schema for the specific version
+        schema = None
+        for ver in crd.get("spec", {}).get("versions", []):
+            if ver.get("name") == version:
+                schema = ver.get("schema", {}).get("openAPIV3Schema")
+                break
+
+        # Cache the result (including None)
+        _CRD_SCHEMA_CACHE[cache_key] = schema
+
+        if schema is None:
+            logger.debug(f"Version '{version}' not found in CRD '{crd_name}'")
+
+        return schema
+
+    except subprocess.TimeoutExpired:
+        logger.debug(
+            f"Timeout accessing cluster for CRD '{crd_name}' - cluster may be unreachable"
+        )
+        _CRD_SCHEMA_CACHE[cache_key] = None
+        return None
+    except FileNotFoundError:
+        logger.debug(
+            "kubectl command not found - please install kubectl or disable K8s validation"
+        )
+        _CRD_SCHEMA_CACHE[cache_key] = None
+        return None
+    except json.JSONDecodeError as e:
+        logger.debug(
+            f"Invalid JSON response from kubectl for CRD '{crd_name}': {e}"
+        )
+        _CRD_SCHEMA_CACHE[cache_key] = None
+        return None
+    except Exception as e:
+        logger.debug(f"Unexpected error accessing CRD '{crd_name}': {e}")
+        _CRD_SCHEMA_CACHE[cache_key] = None
+        return None
+
+
+def clean_schema(schema: dict) -> dict:
+    """Remove Kubernetes-specific OpenAPI extensions that fastjsonschema doesn't support"""
+    cleaned = deepcopy(schema)
+
+    def clean_node(node):
+        if isinstance(node, dict):
+            # Remove unsupported formats
+            if "format" in node and node["format"] in [
+                "int32",
+                "int64",
+                "byte",
+                "date-time",
+            ]:
+                del node["format"]
+
+            # Remove Kubernetes extensions
+            for key in list(node.keys()):
+                if key.startswith("x-kubernetes-"):
+                    del node[key]
+
+            # Recursively clean children
+            for value in node.values():
+                if isinstance(value, dict | list):
+                    clean_node(value)
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, dict | list):
+                    clean_node(item)
+
+    clean_node(cleaned)
+    return cleaned
+
+
+def make_partial_schema(schema: dict, relax_oneof: bool = False) -> dict:
+    """Remove required field constraints for partial validation"""
+    partial = deepcopy(schema)
+
+    def remove_constraints(node):
+        if isinstance(node, dict):
+            node.pop("required", None)
+
+            # Also remove oneOf/anyOf when requested (for CEL expressions)
+            if relax_oneof:
+                node.pop("oneOf", None)
+                node.pop("anyOf", None)
+
+            for value in node.values():
+                if isinstance(value, dict | list):
+                    remove_constraints(value)
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, dict | list):
+                    remove_constraints(item)
+
+    remove_constraints(partial)
+    return partial
+
+
+def validate_spec(
+    spec_data: dict,
+    api_version: str,
+    kind: str,
+    plural: str | None = None,
+    allow_partial: bool = False,
+) -> list[str]:
+    """Validate resource spec against CRD schema"""
+    schema = get_crd_schema(api_version, kind, plural)
+    if not schema:
+        return []
+
+    # Clean and prepare schema
+    schema = clean_schema(schema)
+
+    # Get spec schema if it exists
+    spec_schema = schema.get("properties", {}).get("spec", schema)
+
+    # Check if we need partial validation
+    has_cel = has_cel_expressions(spec_data)
+
+    if allow_partial:
+        # Use partial validation (remove required constraints)
+        spec_schema = make_partial_schema(spec_schema, relax_oneof=has_cel)
+    elif has_cel:
+        # Only relax oneOf/anyOf for CEL expressions, keep required fields
+        spec_schema = make_partial_schema(spec_schema, relax_oneof=True)
+        # Reset required fields from original schema
+        original_spec = schema.get("properties", {}).get("spec", schema)
+        if "required" in original_spec:
+            spec_schema["required"] = original_spec["required"]
+
+    # Replace CEL expressions with valid placeholders
+    if has_cel:
+        validation_data = replace_cel_with_placeholders(spec_data, spec_schema)
+    else:
+        validation_data = spec_data
+
+    # Custom approach to collect multiple errors by validating individual fields
+    errors = []
+
+    def validate_field(field_path, field_value, field_schema):
+        """Validate a single field and collect errors"""
+        if not isinstance(field_schema, dict):
+            return
+
+        # Check type validation
+        expected_type = field_schema.get("type")
+        if expected_type:
+            if expected_type == "integer" and not isinstance(field_value, int):
+                if isinstance(field_value, str):
+                    errors.append(f"spec.{field_path} must be integer")
+            elif expected_type == "number" and not isinstance(
+                field_value, (int, float)
+            ):
+                if isinstance(field_value, str):
+                    errors.append(f"spec.{field_path} must be number")
+            elif expected_type == "string" and not isinstance(field_value, str):
+                errors.append(f"spec.{field_path} must be string")
+            elif expected_type == "boolean" and not isinstance(
+                field_value, bool
+            ):
+                errors.append(f"spec.{field_path} must be boolean")
+
+        # Recurse into objects
+        if isinstance(field_value, dict) and "properties" in field_schema:
+            for prop_name, prop_value in field_value.items():
+                prop_schema = field_schema["properties"].get(prop_name, {})
+                validate_field(
+                    f"{field_path}.{prop_name}", prop_value, prop_schema
+                )
+
+    # Start validation from root
+    if "properties" in spec_schema:
+        for field_name, field_value in validation_data.items():
+            field_schema = spec_schema["properties"].get(field_name, {})
+            validate_field(field_name, field_value, field_schema)
+
+    # Skip errors for CEL fields
+    filtered_errors = []
+    for error_msg in errors:
+        if not is_cel_related_error(error_msg, {"spec": spec_data}):
+            filtered_errors.append(error_msg)
+
+    return filtered_errors
+
+
+def merge_overlays(base: dict, *overlays: dict) -> dict:
+    """Deep merge overlays into base resource"""
+    result = deepcopy(base)
+
+    for overlay in overlays:
+        if not overlay:
+            continue
+
+        def deep_merge(target: dict, source: dict):
+            for key, value in source.items():
+                if (
+                    key in target
+                    and isinstance(target[key], dict)
+                    and isinstance(value, dict)
+                ):
+                    deep_merge(target[key], value)
+                else:
+                    target[key] = deepcopy(value)
+
+        deep_merge(result, overlay)
+
+    return result
+
+
+def validate_resource_function(spec: dict) -> list[ValidationError]:
+    """Validate ResourceFunction spec with K8s CRD validation
+
+    If K8s validation is disabled, returns empty list.
+    """
+    if not is_k8s_validation_enabled():
+        return []
+    errors = []
+
+    # Get resource type info
+    api_config = spec.get("apiConfig", {})
+    api_version = api_config.get("apiVersion")
+    kind = api_config.get("kind")
+    plural = api_config.get("plural")
+
+    if not api_version or not kind:
+        return errors
+
+    # Check if create is enabled
+    create_config = spec.get("create", {})
+    create_enabled = create_config.get("enabled", True)
+    create_overlay = create_config.get("overlay")
+
+    # Validate main resource
+    resource_spec = spec.get("resource")
+    if resource_spec and "spec" in resource_spec:
+        # Use partial validation only if create disabled or has create overlay
+        # (CEL expressions are handled automatically in validate_spec)
+        allow_partial = not create_enabled or create_overlay is not None
+
+        validation_errors = validate_spec(
+            resource_spec["spec"], api_version, kind, plural, allow_partial
+        )
+
+        for error in validation_errors:
+            errors.append(
+                ValidationError(
+                    path="spec.resource",
+                    message=f"Resource validation: {error}",
+                )
+            )
+
+    # Validate overlays (always partial)
+    for i, overlay_item in enumerate(spec.get("overlays", [])):
+        overlay_spec = overlay_item.get("overlay", {}).get("spec")
+        if overlay_spec:
+            validation_errors = validate_spec(
+                overlay_spec, api_version, kind, plural, allow_partial=True
+            )
+
+            for error in validation_errors:
+                errors.append(
+                    ValidationError(
+                        path=f"spec.overlays[{i}].overlay",
+                        message=f"Overlay validation: {error}",
+                    )
+                )
+
+    # Validate create overlay (merged with resource + overlays)
+    if create_overlay and resource_spec:
+        # Merge resource + overlays + create overlay
+        overlays = [
+            item.get("overlay", {}) for item in spec.get("overlays", [])
+        ]
+        merged = merge_overlays(resource_spec, *overlays, create_overlay)
+
+        if "spec" in merged:
+            use_partial = not create_enabled
+            validation_errors = validate_spec(
+                merged["spec"], api_version, kind, plural, use_partial
+            )
+
+            for error in validation_errors:
+                errors.append(
+                    ValidationError(
+                        path="spec.create.overlay",
+                        message=f"Create overlay validation (merged): {error}",
+                    )
+                )
+
+    return errors
+
+
+
+
+# Public API for compatibility
+def validate_resource_function_k8s(spec: dict) -> list[dict]:
+    """Public API - validate ResourceFunction spec and return dict format"""
+    errors = validate_resource_function(spec)
+    return [
+        {"path": e.path, "message": e.message, "severity": e.severity}
+        for e in errors
+    ]

--- a/tests/test_k8s_validation.py
+++ b/tests/test_k8s_validation.py
@@ -1,0 +1,256 @@
+"""Tests for K8s validation functionality."""
+
+import pytest
+from unittest.mock import Mock, patch
+from lsprotocol import types
+
+from koreo_tooling.k8s_validation import (
+    validate_resource_function,
+    validate_spec,
+    is_k8s_validation_enabled,
+    set_k8s_validation_enabled,
+)
+from koreo_tooling.error_handling import ValidationError
+
+
+class TestK8sValidation:
+    """Test suite for K8s validation functions."""
+
+    def setup_method(self):
+        """Setup for each test method."""
+        # Ensure K8s validation is enabled for tests
+        set_k8s_validation_enabled(True)
+
+    def test_validate_resource_function_with_invalid_types(self):
+        """Test validation detects multiple type errors."""
+        spec = {
+            "apiConfig": {
+                "apiVersion": "aws.konfigurate.realkinetic.com/v1beta1",
+                "kind": "AwsEnvironment",
+                "name": "=inputs.metadata.name",
+                "namespace": "=inputs.namespaceName",
+                "plural": "awsenvironments",
+            },
+            "resource": {
+                "spec": {
+                    "autoScalingGroup": {
+                        "maxReplicas": "invalid_string",  # Should be integer
+                        "minReplicas": "another_string",  # Should be integer
+                        "targetCapacity": 49,  # Valid integer
+                    }
+                }
+            },
+        }
+
+        with patch("koreo_tooling.k8s_validation.get_crd_schema") as mock_get_schema:
+            # Mock a schema that requires maxReplicas and minReplicas to be integers
+            mock_schema = {
+                "properties": {
+                    "spec": {
+                        "type": "object",
+                        "properties": {
+                            "autoScalingGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "maxReplicas": {"type": "integer"},
+                                    "minReplicas": {"type": "integer"},
+                                    "targetCapacity": {"type": "integer"},
+                                },
+                            }
+                        },
+                    }
+                }
+            }
+            mock_get_schema.return_value = mock_schema
+
+            errors = validate_resource_function(spec)
+
+            assert len(errors) == 2
+            error_messages = [error.message for error in errors]
+            assert any("maxReplicas must be integer" in msg for msg in error_messages)
+            assert any("minReplicas must be integer" in msg for msg in error_messages)
+
+    def test_validate_resource_function_with_valid_spec(self):
+        """Test validation passes with valid specification."""
+        spec = {
+            "apiConfig": {
+                "apiVersion": "aws.konfigurate.realkinetic.com/v1beta1",
+                "kind": "AwsEnvironment",
+                "plural": "awsenvironments",
+            },
+            "resource": {
+                "spec": {
+                    "autoScalingGroup": {
+                        "maxReplicas": 10,  # Valid integer
+                        "minReplicas": 1,   # Valid integer
+                        "targetCapacity": 49,
+                    }
+                }
+            },
+        }
+
+        with patch("koreo_tooling.k8s_validation.get_crd_schema") as mock_get_schema:
+            mock_schema = {
+                "properties": {
+                    "spec": {
+                        "type": "object",
+                        "properties": {
+                            "autoScalingGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "maxReplicas": {"type": "integer"},
+                                    "minReplicas": {"type": "integer"},
+                                    "targetCapacity": {"type": "integer"},
+                                },
+                            }
+                        },
+                    }
+                }
+            }
+            mock_get_schema.return_value = mock_schema
+
+            errors = validate_resource_function(spec)
+            assert len(errors) == 0
+
+    def test_validate_resource_function_disabled(self):
+        """Test validation returns empty when disabled."""
+        set_k8s_validation_enabled(False)
+        
+        spec = {
+            "apiConfig": {
+                "apiVersion": "aws.konfigurate.realkinetic.com/v1beta1",
+                "kind": "AwsEnvironment",
+            },
+            "resource": {
+                "spec": {
+                    "autoScalingGroup": {
+                        "maxReplicas": "invalid_string",
+                    }
+                }
+            },
+        }
+
+        errors = validate_resource_function(spec)
+        assert len(errors) == 0
+
+    def test_validate_resource_function_missing_crd(self):
+        """Test validation handles missing CRD gracefully."""
+        spec = {
+            "apiConfig": {
+                "apiVersion": "nonexistent.example.com/v1",
+                "kind": "NonexistentKind",
+            },
+            "resource": {"spec": {}},
+        }
+
+        with patch("koreo_tooling.k8s_validation.get_crd_schema") as mock_get_schema:
+            mock_get_schema.return_value = None
+
+            errors = validate_resource_function(spec)
+            assert len(errors) == 0
+
+    def test_validate_spec_custom_validation_logic(self):
+        """Test the custom validation logic that detects multiple errors."""
+        spec_data = {
+            "autoScalingGroup": {
+                "maxReplicas": "string_value",  # Should be integer
+                "minReplicas": "another_string",  # Should be integer
+                "enabled": "not_boolean",       # Should be boolean
+                "targetCapacity": 49,           # Valid integer
+            }
+        }
+        
+        schema = {
+            "properties": {
+                "autoScalingGroup": {
+                    "type": "object",
+                    "properties": {
+                        "maxReplicas": {"type": "integer"},
+                        "minReplicas": {"type": "integer"},
+                        "enabled": {"type": "boolean"},
+                        "targetCapacity": {"type": "integer"},
+                    },
+                }
+            }
+        }
+
+        with patch("koreo_tooling.k8s_validation.get_crd_schema") as mock_get_schema:
+            mock_get_schema.return_value = schema
+
+            errors = validate_spec(spec_data, "test.example.com/v1", "TestKind")
+            
+            assert len(errors) >= 2  # Should detect multiple type errors
+            error_str = " ".join(errors)
+            assert "maxReplicas must be integer" in error_str
+            assert "minReplicas must be integer" in error_str
+
+    def test_validation_error_creation(self):
+        """Test ValidationError creation and diagnostic conversion."""
+        error = ValidationError(
+            message="spec.autoScalingGroup.maxReplicas must be integer",
+            path="spec.resource",
+            line=22,
+            character=8,
+        )
+
+        diagnostic = error.to_diagnostic()
+        
+        assert isinstance(diagnostic, types.Diagnostic)
+        assert diagnostic.message == "spec.autoScalingGroup.maxReplicas must be integer"
+        assert diagnostic.range.start.line == 22
+        assert diagnostic.range.start.character == 8
+        assert diagnostic.severity == types.DiagnosticSeverity.Error
+        assert diagnostic.source == "koreo"
+
+    def test_k8s_validation_enable_disable(self):
+        """Test enabling and disabling K8s validation."""
+        # Test enabling
+        set_k8s_validation_enabled(True)
+        assert is_k8s_validation_enabled() is True
+
+        # Test disabling
+        set_k8s_validation_enabled(False)
+        assert is_k8s_validation_enabled() is False
+
+    def test_cel_expression_handling(self):
+        """Test validation handles CEL expressions correctly."""
+        spec = {
+            "apiConfig": {
+                "apiVersion": "aws.konfigurate.realkinetic.com/v1beta1",
+                "kind": "AwsEnvironment",
+            },
+            "resource": {
+                "spec": {
+                    "name": "=inputs.metadata.name",  # CEL expression
+                    "autoScalingGroup": {
+                        "maxReplicas": "invalid_string",  # Should still be caught
+                    }
+                }
+            },
+        }
+
+        with patch("koreo_tooling.k8s_validation.get_crd_schema") as mock_get_schema:
+            mock_schema = {
+                "properties": {
+                    "spec": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "autoScalingGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "maxReplicas": {"type": "integer"},
+                                },
+                            }
+                        },
+                    }
+                }
+            }
+            mock_get_schema.return_value = mock_schema
+
+            errors = validate_resource_function(spec)
+            
+            # Should detect the type error but not complain about CEL expression
+            assert len(errors) >= 1
+            error_messages = [error.message for error in errors]
+            assert any("maxReplicas must be integer" in msg for msg in error_messages)

--- a/tests/test_server_k8s_integration.py
+++ b/tests/test_server_k8s_integration.py
@@ -1,0 +1,335 @@
+"""Tests for K8s validation integration in the language server."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from lsprotocol import types
+
+from koreo_tooling.server import _validate_k8s_resources, _find_field_position
+from koreo_tooling.langserver.fileprocessor import SemanticRangeIndex
+from koreo_tooling.error_handling import ValidationError
+
+
+class TestServerK8sIntegration:
+    """Test suite for K8s validation integration in the language server."""
+
+    def test_validate_k8s_resources_with_errors(self):
+        """Test _validate_k8s_resources function detects and converts errors."""
+        # Mock semantic range index
+        range_info = types.Range(
+            start=types.Position(line=2, character=0),
+            end=types.Position(line=5, character=20)
+        )
+        
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=range_info,
+                version=None
+            )
+        ]
+
+        # Mock cache response
+        mock_cached = Mock()
+        mock_cached.resource = Mock()
+        mock_cached.spec = {
+            "apiConfig": {
+                "apiVersion": "aws.konfigurate.realkinetic.com/v1beta1",
+                "kind": "AwsEnvironment",
+            },
+            "resource": {
+                "spec": {
+                    "autoScalingGroup": {
+                        "maxReplicas": "invalid_string"
+                    }
+                }
+            }
+        }
+
+        # Mock validation errors
+        validation_errors = [
+            ValidationError(
+                message="spec.autoScalingGroup.maxReplicas must be integer",
+                path="spec.resource",
+                line=0,
+                character=0
+            )
+        ]
+
+        with patch("koreo_tooling.server.cache.get_resource_system_data_from_cache") as mock_cache, \
+             patch("koreo_tooling.k8s_validation.validate_resource_function") as mock_validate, \
+             patch("koreo_tooling.k8s_validation.is_k8s_validation_enabled") as mock_enabled:
+            
+            mock_cache.return_value = mock_cached
+            mock_validate.return_value = validation_errors
+            mock_enabled.return_value = True
+
+            diagnostics = _validate_k8s_resources(semantic_range_index)
+
+            assert len(diagnostics) >= 1
+            
+            # Find the validation diagnostic
+            validation_diagnostic = None
+            for diagnostic in diagnostics:
+                if "K8s validation:" in diagnostic.message:
+                    validation_diagnostic = diagnostic
+                    break
+            
+            assert validation_diagnostic is not None
+            assert "spec.autoScalingGroup.maxReplicas must be integer" in validation_diagnostic.message
+            assert validation_diagnostic.severity == types.DiagnosticSeverity.Error
+            assert validation_diagnostic.source == "k8s-validation"
+
+    def test_validate_k8s_resources_disabled(self):
+        """Test _validate_k8s_resources returns empty when disabled."""
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=types.Range(
+                    start=types.Position(line=2, character=0),
+                    end=types.Position(line=5, character=20)
+                ),
+                version=None
+            )
+        ]
+
+        with patch("koreo_tooling.k8s_validation.is_k8s_validation_enabled") as mock_enabled:
+            mock_enabled.return_value = False
+            
+            diagnostics = _validate_k8s_resources(semantic_range_index)
+            assert len(diagnostics) == 0
+
+    def test_validate_k8s_resources_no_cache(self):
+        """Test _validate_k8s_resources handles missing cache gracefully."""
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=types.Range(
+                    start=types.Position(line=2, character=0),
+                    end=types.Position(line=5, character=20)
+                ),
+                version=None
+            )
+        ]
+
+        with patch("koreo_tooling.server.cache.get_resource_system_data_from_cache") as mock_cache, \
+             patch("koreo_tooling.k8s_validation.is_k8s_validation_enabled") as mock_enabled:
+            
+            mock_cache.return_value = None  # No cached resource
+            mock_enabled.return_value = True
+            
+            diagnostics = _validate_k8s_resources(semantic_range_index)
+            assert len(diagnostics) == 0
+
+    def test_find_field_position_exact_match(self):
+        """Test _find_field_position finds exact field location."""
+        # Mock semantic range index
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=types.Range(
+                    start=types.Position(line=2, character=0),
+                    end=types.Position(line=5, character=20)
+                ),
+                version=None
+            )
+        ]
+        
+        default_range = types.Range(
+            start=types.Position(line=0, character=0),
+            end=types.Position(line=0, character=10)
+        )
+
+        # Mock document with field content
+        mock_doc = Mock()
+        mock_doc.lines = [
+            "apiVersion: koreo.dev/v1beta1",
+            "kind: ResourceFunction",
+            "metadata:",
+            "  name: test-function",
+            "spec:",
+            "  resource:",
+            "    spec:",
+            "      autoScalingGroup:",
+            "        maxReplicas: \"invalid\"",  # Line 8
+            "        minReplicas: 1"
+        ]
+
+        # Mock the server module properly
+        mock_server = Mock()
+        mock_server.workspace.get_text_document.return_value = mock_doc
+        
+        with patch("koreo_tooling.server.server", mock_server):
+            
+            result_range = _find_field_position(
+                semantic_range_index, 
+                "test-function", 
+                "spec.autoScalingGroup.maxReplicas",
+                default_range
+            )
+            
+            # Should find the exact line and position of maxReplicas
+            assert result_range.start.line == 8
+            assert result_range.start.character == 8  # Position of "maxReplicas"
+            assert result_range.end.character == 8 + len("maxReplicas")
+
+    def test_find_field_position_fallback_to_spec(self):
+        """Test _find_field_position falls back to spec section when field not found."""
+        # Mock semantic range index with def range
+        def_range = types.Range(
+            start=types.Position(line=2, character=0),
+            end=types.Position(line=5, character=20)
+        )
+        
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=def_range,
+                version=None
+            )
+        ]
+        
+        default_range = types.Range(
+            start=types.Position(line=0, character=0),
+            end=types.Position(line=0, character=10)
+        )
+
+        # Mock document without the specific field
+        mock_doc = Mock()
+        mock_doc.lines = [
+            "apiVersion: koreo.dev/v1beta1",
+            "kind: ResourceFunction",
+            "metadata:",
+            "  name: test-function",
+            "spec:",
+            "  resource:",
+            "    spec:",
+            "      # field not found here"
+        ]
+
+        # Mock the server module properly
+        mock_server = Mock()
+        mock_server.workspace.get_text_document.return_value = mock_doc
+        
+        with patch("koreo_tooling.server.server", mock_server):
+            
+            result_range = _find_field_position(
+                semantic_range_index, 
+                "test-function", 
+                "spec.autoScalingGroup.nonexistentField",
+                default_range
+            )
+            
+            # Should fall back to approximate spec location (def_range.start.line + 5)
+            expected_line = def_range.start.line + 5  # Line 7
+            assert result_range.start.line == expected_line
+            assert result_range.start.character == 0
+
+    def test_find_field_position_no_semantic_info(self):
+        """Test _find_field_position returns default when no semantic info available."""
+        semantic_range_index = []  # Empty
+        
+        default_range = types.Range(
+            start=types.Position(line=0, character=0),
+            end=types.Position(line=0, character=10)
+        )
+        
+        result_range = _find_field_position(
+            semantic_range_index, 
+            "test-function", 
+            "spec.autoScalingGroup.maxReplicas",
+            default_range
+        )
+        
+        # Should return the default range unchanged
+        assert result_range == default_range
+
+    def test_find_field_position_handles_exception(self):
+        """Test _find_field_position handles exceptions gracefully."""
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=types.Range(
+                    start=types.Position(line=2, character=0),
+                    end=types.Position(line=5, character=20)
+                ),
+                version=None
+            )
+        ]
+        
+        default_range = types.Range(
+            start=types.Position(line=0, character=0),
+            end=types.Position(line=0, character=10)
+        )
+
+        # Mock the server to raise an exception
+        mock_server = Mock()
+        mock_server.workspace.get_text_document.side_effect = Exception("Document not found")
+        
+        with patch("koreo_tooling.server.server", mock_server):
+            
+            result_range = _find_field_position(
+                semantic_range_index, 
+                "test-function", 
+                "spec.autoScalingGroup.maxReplicas",
+                default_range
+            )
+            
+            # Should fall back to spec approximation since file search failed
+            assert result_range.start.line == 7  # 2 + 5
+            assert result_range.start.character == 0
+
+    def test_multiple_validation_errors_create_multiple_diagnostics(self):
+        """Test that multiple validation errors create multiple diagnostics."""
+        range_info = types.Range(
+            start=types.Position(line=2, character=0),
+            end=types.Position(line=5, character=20)
+        )
+        
+        semantic_range_index = [
+            SemanticRangeIndex(
+                uri="file:///test.yaml",
+                name="ResourceFunction:test-function:def",
+                range=range_info,
+                version=None
+            )
+        ]
+
+        mock_cached = Mock()
+        mock_cached.resource = Mock()
+        mock_cached.spec = {"apiConfig": {}, "resource": {"spec": {}}}
+
+        # Multiple validation errors
+        validation_errors = [
+            ValidationError(
+                message="spec.autoScalingGroup.maxReplicas must be integer",
+                path="spec.resource",
+            ),
+            ValidationError(
+                message="spec.autoScalingGroup.minReplicas must be integer", 
+                path="spec.resource",
+            )
+        ]
+
+        with patch("koreo_tooling.server.cache.get_resource_system_data_from_cache") as mock_cache, \
+             patch("koreo_tooling.k8s_validation.validate_resource_function") as mock_validate, \
+             patch("koreo_tooling.k8s_validation.is_k8s_validation_enabled") as mock_enabled:
+            
+            mock_cache.return_value = mock_cached
+            mock_validate.return_value = validation_errors
+            mock_enabled.return_value = True
+
+            diagnostics = _validate_k8s_resources(semantic_range_index)
+
+            # Should have diagnostics for both validation errors
+            validation_diagnostics = [d for d in diagnostics if "K8s validation:" in d.message]
+            assert len(validation_diagnostics) == 2
+            
+            messages = [d.message for d in validation_diagnostics]
+            assert any("maxReplicas must be integer" in msg for msg in messages)
+            assert any("minReplicas must be integer" in msg for msg in messages)


### PR DESCRIPTION
# Add K8s CRD validation for ResourceFunctions

## Summary

Adds real-time K8s CRD validation to the language server, enabling type checking of ResourceFunction specs against cluster CRD schemas.

## Features

- **Real-time validation** - Type checking against actual CRD schemas from cluster
- **LSP integration** - Validation errors appear as diagnostics in editor
- **CEL expression support** - Handles CEL expressions during validation
- **Smart caching** - CRD schemas cached to avoid repeated kubectl calls
- **Graceful fallback** - Handles missing CRDs and connectivity issues

## Configuration

- `KOREO_SKIP_K8S_VALIDATION=1` to disable
- Requires `plural` field in `apiConfig` for safety

## Breaking Changes

ResourceFunctions now require explicit `plural` in `apiConfig`:

```yaml
apiConfig:
  apiVersion: "example.com/v1"
  kind: "MyResource"
  plural: "myresources"  # Now required
```

## Implementation

- Uses `kubectl get crd` for schema fetching
- Type-only validation (no required fields - overlays handle those)
- 30s timeout with error handling
- Comprehensive test coverage (610 new test lines)

## Benefits

- Catch type errors at authoring time
- Prevent invalid ResourceFunctions 
- Improved developer experience with real-time feedback

Enables early validation of ResourceFunction specs before cluster deployment.